### PR TITLE
CU-ux5gh1: Added publish to github registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+        registry-url: 'https://npm.pkg.github.com'
+        scope: '@kredfeed'
+    - run: npm ci
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kredfeed/eslint-config-kredfeed",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Common eslint config for kredfeed",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I'm going to remove the package that is in npm registry and move it to github. This is so that all our packages come from github registry instead of having to paid to publish private packages in npm registry. 

could you remove yourself as a maintainer here so that I can delete this package.
it won't like me if there are to maintainers 
https://docs.npmjs.com/transferring-a-package-from-a-user-account-to-another-user-account

![Screen Shot 2021-05-12 at 2 21 54 PM](https://user-images.githubusercontent.com/8495952/118032569-70a9ab80-b32d-11eb-8e74-0de80f38565e.jpg)
